### PR TITLE
added reference to manifest.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>PWAConf</title>
+    
+    <link rel="manifest" href="./manifest.json" />
+    
     <link rel="stylesheet" href="./styles.css" />
 
     <link rel="icon" type="image/png" href="./img/icons/favicon.png" />


### PR DESCRIPTION
This PR adds a reference to the `manifest.json` from `index.html`. Due to this missing reference, the app cannot be installed locally. Additionally, the next tutorial in the series: https://vaadin.com/tutorials/learn-pwa/production-pwa-webpack-setup provides an incorrect base project as it's missing this reference (which might be the reason for #1 )